### PR TITLE
AAR fix for NoClassDefFoundError

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     internalImplementation project(path: ':sdk-data')
     internalImplementation project(path: ':sdk-domain')
 
-    externalImplementation("com.github.sonect:android-user-sdk:$sonectSdkVersion") {
+    externalApi("com.github.sonect:android-user-sdk:$sonectSdkVersion") {
         exclude group: "idenfySdk"
         exclude group: "io.anyline"
     }


### PR DESCRIPTION
Quoted text: `Since you've used the "implementation" keyword, those dependencies are considered private to the .aar, and will not be listed in the pom.xml. So they will not be available in your aar, and not automatically imported into the project by gradle.

If you change to the api keyword to "api" instead of implementation, those dependencies become public, and should be listed in the generated pom.xml, and thus should be automatically imported into the project.`